### PR TITLE
Now composes postgres image with ALL the data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+up:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE}
+
+pull:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml pull

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
  ons-postgres:
   container_name: postgres
-  image: sdcplatform/postgres
+  image: sdcplatform/dev-postgres
   ports:
    - "${EX_POSTGRES_PORT}:5432"
  secure-message-postgres:


### PR DESCRIPTION
A new image, sdcplatform/dev-postgres has been created to include all
data generated by the integration test.  By default now, using these
compose files will spin up this postgres instance instead of the empty
one. Should now be possible to start developing/testing from a docker-compose.

NOTE: docker hub build for this needs to be working before this pull request is merged