### PR TITLE
Change backstage_api_url

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -191,7 +191,7 @@ services:
     ports:
       - 8085:8085
     environment:
-      - BACKSTAGE_API_URL=http://backstage:${BACKSTAGE_PORT}/backstage-api/v1
+      - BACKSTAGE_API_URL=http://backstage:${BACKSTAGE_PORT}/backstage-api
     external_links:
       - backstage:backstage
     networks:


### PR DESCRIPTION
BACKSTAGE_API_URL has changed in ras-backstage to allow for v1/v2/v3 