### PR TITLE
Disable UAA by default

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -192,6 +192,7 @@ services:
       - 8085:8085
     environment:
       - BACKSTAGE_API_URL=http://backstage:${BACKSTAGE_PORT}/backstage-api
+      - USE_UAA=0
     external_links:
       - backstage:backstage
     networks:

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -168,6 +168,7 @@ services:
       - RM_SAMPLE_SERVICE_HOST=${SAMPLE_HOST}
       - RM_SAMPLE_SERVICE_PORT=${SAMPLE_PORT}
       - RAS_PARTY_SERVICE_HOST=${PARTY_HOST}
+      - USE_UAA=0
     networks:
       - rasrmdockerdev_default
 
@@ -193,7 +194,6 @@ services:
       - 8085:8085
     environment:
       - BACKSTAGE_API_URL=http://backstage:${BACKSTAGE_PORT}/backstage-api
-      - USE_UAA=0
     external_links:
       - backstage:backstage
     networks:


### PR DESCRIPTION
Since we don't have any docker instance of UAA running currently it makes sense to disable UAA when running response-operations-ui through docker