### PR TITLE
Added a backstage host variable to the environment for R-Ops-UI

### DIFF
--- a/.env
+++ b/.env
@@ -98,6 +98,7 @@ DJANGO_CLIENT_ID=ons@ons.gov
 
 # Backstage
 BACKSTAGE_PORT=8001
+BACKSTAGE_HOST=backstage
 
 # OAuth
 OAUTH_PORT=8040

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -236,7 +236,7 @@ services:
     ports:
       - 8085:8085
     environment:
-      - BACKSTAGE_API_URL=http://backstage:${BACKSTAGE_PORT}/backstage-api
+      - BACKSTAGE_API_URL=http://${BACKSTAGE_HOST}:${BACKSTAGE_PORT}/backstage-api
     external_links:
       - backstage:backstage
     networks:


### PR DESCRIPTION
This change allows you to run backstage locally with the response-operations-ui docker container by setting the environment variable `export BACKSTAGE_HOST=docker.for.mac.host.internal` on mac or set to the machine's IP before `make up`. Previously you would have to edit the the `ras-services.yml` locally to achieve this.