### PR TITLE
add missing config for collection-instrument service

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -173,6 +173,8 @@ services:
       - CONFIG_YML=config/config-docker.yaml
       - ONS_CRYPTOKEY=somethingsecure
       - COLLECTION_EXERCISE_HOST=${COLLEX_HOST}
+      - CASE_SERVICE_HOST=${CASE_HOST}
+      - RM_SURVEY_SERVICE_HOST=${SURVEY_HOST}
     networks:
       - rasrmdockerdev_default
     external_links:


### PR DESCRIPTION
uploading a response sheet was failing as the collection instrument
service was missing config items for CASE_SERVICE_HOST and
RM_SURVEY_SERVICE_HOST meaning they were defaulting to localhost
(which doesn't work in the docker envs)