### PR TITLE
Restart unhealthy services

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -39,6 +39,7 @@ services:
       - RAS_COLLECTION_INSTRUMENT_SERVICE_PROTOCOL=http
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${FRONTSTAGE_API_PORT}/info"]
       interval: 1m30s
@@ -66,6 +67,7 @@ services:
       - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PARTY_PORT}/info"]
       interval: 1m30s
@@ -96,6 +98,7 @@ services:
       - CLIENT_SECRET=password
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${SECURE_MESSAGE_PORT}/info"]
       interval: 1m30s
@@ -144,6 +147,7 @@ services:
       -  PORT=8082
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${FRONTSTAGE_PORT}/info"]
       interval: 1m30s
@@ -171,6 +175,7 @@ services:
       - rasrmdockerdev_default
     external_links:
       - postgres:ras-postgres
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${COLL_INST_PORT}/info"]
       interval: 1m30s
@@ -205,6 +210,7 @@ services:
       - rasrmdockerdev_default
     external_links:
       - uaa
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${BACKSTAGE_PORT}/info"]
       interval: 1m30s
@@ -225,6 +231,7 @@ services:
       - postgres:ras-postgres
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8040/info"]
       interval: 1m30s
@@ -246,6 +253,7 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8085/info"]
       interval: 1m30s

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -33,6 +33,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8125/info"]
       interval: 1m30s
@@ -69,6 +70,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8171/info"]
       interval: 1m30s
@@ -108,6 +110,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8151/info"]
       interval: 1m30s
@@ -142,6 +145,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8141/info"]
       interval: 1m30s
@@ -172,6 +176,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8121/info"]
       interval: 1m30s
@@ -204,6 +209,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8191/info"]
       interval: 1m30s
@@ -247,6 +253,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8145/info"]
       interval: 1m30s
@@ -264,6 +271,7 @@ services:
      - DATABASE_URL=postgres://postgres:postgres@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres?sslmode=disable
      - security_user_name=${SURVEY_USER}
      - security_user_password=${SURVEY_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/info"]
       interval: 1m30s
@@ -289,6 +297,7 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "-XGET", "http://localhost:8181/info"]
       interval: 1m30s
@@ -306,6 +315,7 @@ services:
       - SQLALCHEMY_DATABASE_URI=postgres://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres
       - SECURITY_USER_NAME=${SECURITY_USER_NAME}
       - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "-XGET", "http://localhost:8182/info"]
       interval: 1m30s


### PR DESCRIPTION
If services are unhealthy or have died then restart them. This should
resolve the issue with sample service dying because of the pycryto
extension as it will restart and should work the next time around.