### PR TITLE
Handle psycopg2 engine connection errors

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ sqlalchemy = "*"
 "psycopg2-binary" = "*"
 
 [dev-packages]
+retrying = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b520fd64fd67e534a75cc08394a03219cbeb7bb94870d898731624717e0198e5"
+            "sha256": "7999bb801353a289441244db7ebccafcd1b53ef0617474ea0475a7e2f04f3ef4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,5 +57,20 @@
             "version": "==1.2.7"
         }
     },
-    "develop": {}
+    "develop": {
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "index": "pypi",
+            "version": "==1.3.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        }
+    }
 }

--- a/setup_database.py
+++ b/setup_database.py
@@ -7,7 +7,13 @@ if __name__ == '__main__':
     password = os.getenv('POSTGRES_PASSWORD')
     port = os.getenv('EX_POSTGRES_PORT')
     engine = sqlalchemy.create_engine(f'postgresql://{username}:{password}@localhost:{port}/postgres')
-    conn = engine.connect()
+
+    try:
+        conn = engine.connect()
+    except sqlalchemy.exc.OperationalError as e:
+        print('Cannot connect to postgres.')
+        exit 0
+
     print('Dropping pgcrypto')
     conn.execute('DROP EXTENSION IF EXISTS pgcrypto;')
     print('Creating pgcrypto')

--- a/setup_database.py
+++ b/setup_database.py
@@ -1,18 +1,26 @@
 import os
 
 import sqlalchemy
+from retrying import retry
+
+def retry_if_sqlalchemy_error(exception):
+    print(f'error has occurred: {str(exception)}')
+    return isinstance(exception, sqlalchemy.exc.OperationalError)
+
+
+@retry(retry_on_exception=retry_if_sqlalchemy_error, wait_fixed=10000, stop_max_delay=600000, wrap_exception=True)
+def retry_connection(engine):
+    return engine.connect()
+
+
 
 if __name__ == '__main__':
     username = os.getenv('POSTGRES_USERNAME')
     password = os.getenv('POSTGRES_PASSWORD')
     port = os.getenv('EX_POSTGRES_PORT')
-    engine = sqlalchemy.create_engine(f'postgresql://{username}:{password}@localhost:{port}/postgres')
 
-    try:
-        conn = engine.connect()
-    except sqlalchemy.exc.OperationalError as e:
-        print('Cannot connect to postgres.')
-        exit 0
+    engine = sqlalchemy.create_engine(f'postgresql://{username}:{password}@localhost:{port}/postgres')
+    conn = retry_connection(engine)
 
     print('Dropping pgcrypto')
     conn.execute('DROP EXTENSION IF EXISTS pgcrypto;')


### PR DESCRIPTION
This pr introduces a try / except block to setup_database.py that gracefully handles connection issues between the psycopg2 engine and the postgres database.

Exceptions are caught, a relevant line is printed to stdout and the script calls exit(0).