### PR TITLE
Install all packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 up:
 	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE} ; docker stop oauth2-service && docker start oauth2-service
-	pipenv install
+	pipenv install --dev
 	pipenv run python setup_database.py
 
 down:


### PR DESCRIPTION
Previously it would install all the packages apart from the dev ones.  There is a new retrying module
added to this that wasn't getting installed, causing a failure on a fresh build.