### PR TITLE
edit config for UAA and response operations

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -271,6 +271,8 @@ services:
       - SECURE_MESSAGE_URL=http://${SECURE_MESSAGE_HOST}:${SECURE_MESSAGE_PORT}
       - RAS_SECURE_MESSAGING_JWT_SECRET=${JWT_SECRET}
       - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
+      - UAA_CLIENT_ID=ras_backstage
+      - UAA_CLIENT_SECRET=password
     external_links:
       - backstage:backstage
       - redis

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -203,7 +203,7 @@ services:
       - RM_IAC_SERVICE_HOST=${IAC_HOST}
       - USE_UAA=1
       - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=ras_backstage
+      - UAA_CLIENT_ID=response_operations
       - UAA_CLIENT_SECRET=password
     networks:
       - rasrmdockerdev_default
@@ -271,7 +271,7 @@ services:
       - SECURE_MESSAGE_URL=http://${SECURE_MESSAGE_HOST}:${SECURE_MESSAGE_PORT}
       - RAS_SECURE_MESSAGING_JWT_SECRET=${JWT_SECRET}
       - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=ras_backstage
+      - UAA_CLIENT_ID=response_operations
       - UAA_CLIENT_SECRET=password
     external_links:
       - backstage:backstage

--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -101,8 +101,8 @@ oauth:
             authorized-grant-types: client_credentials
             authorities: scim.all,clients.all
             resource-ids: oauth
-          ras_backstage:
-            id: ras_backstage
+          response_operations:
+            id: response_operations
             secret: password
             authorized-grant-types: client_credentials,password
             authorities: scim.userids, scim.me, scim.read


### PR DESCRIPTION
Config update for: https://github.com/ONSdigital/response-operations-ui/pull/163

Response operations should directly sign in with UAA.

https://trello.com/c/oodNbXR2/100-response-operations-ui-should-sign-in-directly-using-uaa-not-via-backstage