### PR TITLE
Added plantuml sequence diagram for publishing a collection exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 
 # IDE
 .idea/
+
+plantuml.jar
+
+# Generated diagrams
+diagrams/*.svg

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
-up:
-	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE} ; docker stop oauth2-service && docker start oauth2-service
-	pipenv install --dev
-	pipenv run python setup_database.py
+DIAGRAM_DIR=diagrams
+UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
+SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
 
-down:
-	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml down
+diagrams: download-plantuml $(SVG_FILES)
 
-pull:
-	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml pull ${SERVICE}
-
-logs:
-	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml logs --follow ${SERVICE}
+clean:
+	rm plantuml.jar; rm diagrams/*.svg
 
 download-plantuml:
 ifeq (,$(wildcard plantuml.jar))
@@ -20,4 +15,3 @@ endif
 %.svg : %.puml
 	 java -jar plantuml.jar -tsvg $^
 
-diagrams: download-plantuml diagrams/publish-collection-exercise.svg

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ pull:
 logs:
 	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml logs --follow ${SERVICE}
 
+download-plantuml:
+ifeq (,$(wildcard plantuml.jar))
+	curl -L --output plantuml.jar https://downloads.sourceforge.net/project/plantuml/plantuml.jar
+endif
+
+%.svg : %.puml
+	 java -jar plantuml.jar -tsvg $^
+
+diagrams: download-plantuml diagrams/publish-collection-exercise.svg

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,20 @@ DIAGRAM_DIR=diagrams
 UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
 SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
 
+up:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE} ; docker stop oauth2-service && docker start oauth2-service
+	pipenv install --dev
+	pipenv run python setup_database.py
+
+down:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml down
+
+pull:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml pull ${SERVICE}
+
+logs:
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml logs --follow ${SERVICE}
+
 diagrams: download-plantuml $(SVG_FILES)
 
 clean:

--- a/diagrams/publish-collection-exercise.puml
+++ b/diagrams/publish-collection-exercise.puml
@@ -1,0 +1,27 @@
+@startuml
+skinparam sequence {
+    ParticipantBackgroundColor HoneyDew
+    ActorBackgroundColor HoneyDew
+}
+
+actor User
+participant "Collection Exercise"
+participant Sample
+participant Party
+participant Case
+
+User -> "Collection Exercise" :  POST /collectionexerciseexecution [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpoint.java#L39 *]]
+"Collection Exercise" -> Sample :  POST /samples/sampleunitrequests [[https://github.com/ONSdigital/rm-sample-service/blob/master/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java#L81 *]]
+Sample --> "Collection Exercise" : 201
+"Collection Exercise" --> Party :  PUT /party-api/v1/businesses/sample/link/<sampleSummaryId> [[https://github.com/ONSdigital/ras-party/blob/master/ras_party/views/business_view.py#L69 *]]
+Party --> "Collection Exercise" : 200
+"Collection Exercise" --> User : 201
+Sample ->> "Collection Exercise" :  sample_outbound_exchange(Sample.SampleDelivery) [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java#L28 *]]
+"Collection Exercise" ->> Case :  collection-inbound/outbound-exchange(Case.CaseDelivery) [[https://github.com/ONSdigital/rm-case-service/blob/master/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseCreationReceiverImpl.java#L24 *]]
+note right
+     Collection Exercise is publishing to a different
+     exchange to the one Case is listening on. It 
+     works because the queue names are the same
+end note
+Case -> Action : case-outbound-exchange(Case.LifecycleEvents) [[https://github.com/ONSdigital/rm-action-service/blob/master/src/main/java/uk/gov/ons/ctp/response/action/message/impl/CaseNotificationReceiverImpl.java#L26 *]]
+@enduml


### PR DESCRIPTION
# Motivation and Context
This PR adds a plantuml sequence diagram for 'publish collection exercise' and the means to build it

# What has changed
No code has been changed but the Makefile has been updated

# How to test?
```
make diagrams
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome diagrams/publish-collection-exercise.svg
```
Ensure diagram can be viewed
