### PR TITLE
Update volume and working directory of response-operations-ui

### DIFF
--- a/ras-local.yml
+++ b/ras-local.yml
@@ -211,7 +211,7 @@ services:
     container_name: response-operations-ui
     build: ${RAS_HOME}/response-operations-ui
     volumes:
-      - ${RAS_HOME}/response-operations-ui:/response_operations_ui
+      - ${RAS_HOME}/response-operations-ui:/app
     ports:
       - 8085:8085
     environment:


### PR DESCRIPTION
# What has changed
Update the mount point of the response-operations-ui volume to match the working directory ("/app") in the container (previously "/response-operations-ui").

# How to test?
- Checkout this and the response-operations-ui branch of the same 
- run `SERVICE=response-operations-ui make local`

# Links
Follows changes in PR: ONSdigital/response-operations-ui#172

