### PR TITLE
Remove backstage service

### DIFF
--- a/.env
+++ b/.env
@@ -100,10 +100,6 @@ SECURE_MESSAGE_HOST=secure-message
 # Frontstage
 FRONTSTAGE_PORT=8082
 
-# Backstage
-BACKSTAGE_PORT=8001
-BACKSTAGE_HOST=backstage
-
 # OAuth
 OAUTH_CLIENT_SECRET=password
 OAUTH_CLIENT_ID=ons@ons.gov

--- a/ras-local.yml
+++ b/ras-local.yml
@@ -149,41 +149,6 @@ services:
       timeout: 10s
       retries: 3
 
-  backstage:
-    container_name: backstage
-    build: ${RAS_HOME}/ras-backstage
-    volumes:
-      - ${RAS_HOME}/ras-backstage:/app
-    ports:
-      - "${BACKSTAGE_PORT}:${BACKSTAGE_PORT}"
-    environment:
-      - APP_SETTINGS=DevelopmentConfig
-      - SECURITY_USER_NAME=${SECURITY_USER_NAME}
-      - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
-      - RM_SURVEY_SERVICE_HOST=${SURVEY_HOST}
-      - RM_SURVEY_SERVICE_PORT=${SURVEY_PORT}
-      - RM_COLLECTION_EXERCISE_SERVICE_HOST=${COLLEX_HOST}
-      - RAS_COLLECTION_INSTRUMENT_SERVICE_HOST=${COLL_INST_HOST}
-      - RM_SAMPLE_SERVICE_HOST=${SAMPLE_HOST}
-      - RM_SAMPLE_SERVICE_PORT=${SAMPLE_PORT}
-      - RAS_PARTY_SERVICE_HOST=${PARTY_HOST}
-      - RM_CASE_SERVICE_HOST=${CASE_HOST}
-      - RM_IAC_SERVICE_HOST=${IAC_HOST}
-      - USE_UAA=1
-      - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=response_operations
-      - UAA_CLIENT_SECRET=password
-    networks:
-      - rasrmdockerdev_default
-    external_links:
-      - uaa
-    restart: always
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${BACKSTAGE_PORT}/info"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
-
   oauth2-service:
     container_name: oauth2-service
     build: ${RAS_HOME}/django-oauth2-test
@@ -216,7 +181,6 @@ services:
       - 8085:8085
     environment:
       - APP_SETTINGS=DevelopmentConfig
-      - BACKSTAGE_API_URL=http://${BACKSTAGE_HOST}:${BACKSTAGE_PORT}/backstage-api
       - CASE_URL=http://${CASE_HOST}:${CASE_PORT}
       - CASE_USERNAME=${CASE_USERNAME}
       - CASE_PASSWORD=${CASE_PASSWORD}
@@ -249,7 +213,6 @@ services:
       - UAA_CLIENT_ID=response_operations
       - UAA_CLIENT_SECRET=password
     external_links:
-      - backstage:backstage
       - redis
     networks:
       - rasrmdockerdev_default

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -138,38 +138,6 @@ services:
       timeout: 10s
       retries: 3
 
-  backstage:
-    container_name: backstage
-    image: sdcplatform/ras-backstage
-    ports:
-      - "${BACKSTAGE_PORT}:${BACKSTAGE_PORT}"
-    environment:
-      - SECURITY_USER_NAME=${SECURITY_USER_NAME}
-      - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
-      - RM_SURVEY_SERVICE_HOST=${SURVEY_HOST}
-      - RM_SURVEY_SERVICE_PORT=${SURVEY_PORT}
-      - RM_COLLECTION_EXERCISE_SERVICE_HOST=${COLLEX_HOST}
-      - RAS_COLLECTION_INSTRUMENT_SERVICE_HOST=${COLL_INST_HOST}
-      - RM_SAMPLE_SERVICE_HOST=${SAMPLE_HOST}
-      - RM_SAMPLE_SERVICE_PORT=${SAMPLE_PORT}
-      - RAS_PARTY_SERVICE_HOST=${PARTY_HOST}
-      - RM_CASE_SERVICE_HOST=${CASE_HOST}
-      - RM_IAC_SERVICE_HOST=${IAC_HOST}
-      - USE_UAA=1
-      - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=response_operations
-      - UAA_CLIENT_SECRET=password
-    networks:
-      - rasrmdockerdev_default
-    external_links:
-      - uaa
-    restart: always
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${BACKSTAGE_PORT}/info"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
-
   oauth2-service:
     container_name: oauth2-service
     image: sdcplatform/django-oauth2-test
@@ -197,7 +165,6 @@ services:
     ports:
       - 8085:8085
     environment:
-      - BACKSTAGE_API_URL=http://${BACKSTAGE_HOST}:${BACKSTAGE_PORT}/backstage-api
       - CASE_URL=http://${CASE_HOST}:${CASE_PORT}
       - CASE_USERNAME=${CASE_USERNAME}
       - CASE_PASSWORD=${CASE_PASSWORD}
@@ -228,7 +195,6 @@ services:
       - UAA_CLIENT_ID=response_operations
       - UAA_CLIENT_SECRET=password
     external_links:
-      - backstage:backstage
       - redis
     networks:
       - rasrmdockerdev_default


### PR DESCRIPTION
# What has changed

Following https://github.com/ONSdigital/response-operations-ui/pull/199 backstage can be removed from the docker environment.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- [Trello](https://trello.com/c/0lPdzRbt)
- ~[Remove config PR](https://github.com/ONSdigital/response-operations-ui/pull/199)~
- [Remove from pipeline PR](https://github.com/ONSdigital/ras-deploy/pull/31)
- [Remove from acceptance tests PR](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/144)