### PR TITLE
Sample service lower logging

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -33,6 +33,8 @@ services:
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+     - LOGGING_LEVEL_uk.gov.ons.ctp.response.sample.scheduled.distribution=WARN
+     - LOGGING_LEVEL_uk.gov.ons.ctp.common.distributed=INFO
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8125/info"]

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -28,13 +28,11 @@ services:
      - PARTY_SVC_CONNECTION_CONFIG_USERNAME=${PARTY_USER}
      - PARTY_SVC_CONNECTION_CONFIG_PASSWORD=${PARTY_PASSWORD}
      - SAMPLE_UNIT_DISTRIBUTION_DELAY_MILLI_SECONDS=1000
-     - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${SAMPLE_DEBUG_PORT}
+     - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${SAMPLE_DEBUG_PORT} -Dlogging.level.uk.gov.ons.ctp.response.sample.scheduled.distribution=WARN -Dlogging.level.uk.gov.ons.ctp.common.distributed=INFO
      - LIQUIBASE_USER=${POSTGRES_USERNAME}
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
-     - LOGGING_LEVEL_uk.gov.ons.ctp.response.sample.scheduled.distribution=WARN
-     - LOGGING_LEVEL_uk.gov.ons.ctp.common.distributed=INFO
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8125/info"]


### PR DESCRIPTION
# Motivation and Context
Sample service has a class that polls every 1s in the that
generates a lot of logs. This makes it hard to see any logs of interest
through the other verbose logs.

It will cut out the example below every 1s

```

   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,361","service":"samplesvc","level":"INFO","event":"SampleUnitDistributor is in the house"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,366","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,365","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,364","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,368","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,372","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,375","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,370","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,371","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,374","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,375","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,369","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,369","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,376","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,376","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,380","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,381","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,381","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,382","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,378","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,383","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,385","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,386","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,382","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,387","service":"samplesvc","level":"INFO","event":"SampleUnitsDistributor sleeping"}
```

# What has changed
Added java options to lower the logging for verbose files.

# How to test?
1. `make up`
1. `docker logs sample -f`
1. Check the logs above aren't printed