### PR TITLE
Add full details for uaa_user

### DIFF
--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -118,4 +118,4 @@ oauth:
 
 scim:
    users:
-      - uaa_user|password|scim.me,scim.userids
+      - uaa_user|password|ons@ons|ONS|User|scim.me,scim.userids


### PR DESCRIPTION
# Motivation and Context
Currently, only the username and password are set up when the uaa_user is created through docker-dev.  Secure Message needs the also needs the firstname and lastname and logs out a key error if they're not present, along with the error `UAA didn't return all expected details`.  

This only affects dev environments using the uaa_user in response-ops  and there's no change in functionality but it's a pain when debugging, as you have to filter out loads of the UAA key errors.

The ras-deploy pipeline already sets the uaa_user up with full details so no change is needed there.

# What has changed
Added email, firstname and lastname for uaa_user.

# How to test?
- Run the services locally
- Send a secure message - you should see a lot of key errors and the message `UAA didn't return all expected details`
- `make down`, pull in this branch then `make up`
- The errors should no longer be logged
- All acceptance tests should still pass as normal


# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->