### PR TITLE
Added config to tell action service where to find sample service

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -105,6 +105,8 @@ services:
      - PARTY_SVC_CONNECTION_CONFIG_PASSWORD=${PARTY_PASSWORD}
      - SURVEY_SVC_CONNECTION_CONFIG_HOST=${SURVEY_HOST}
      - SURVEY_SVC_CONNECTION-CONFIG_PORT=${SURVEY_PORT}
+     - SAMPLE_SVC_CONNECTION_CONFIG_HOST=${SAMPLE_HOST}
+     - SAMPLE_SVC_CONNECTION_CONFIG_PORT=${SAMPLE_PORT}
      - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${ACTION_DEBUG_PORT} -Dlogging.level.uk.gov.ons.ctp.response.action.scheduled.plan.PlanScheduler=WARN -Dlogging.level.uk.gov.ons.ctp.response.action.service.impl.ActionPlanJobServiceImpl=WARN
      - LIQUIBASE_USER=${POSTGRES_USERNAME}
      - LIQUIBASE_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
# Motivation and Context
Previously the action service had no knowledge of the sample service.

Today, amidst it all, it does!

# What has changed
Configuration change in rm-services.yml which exposes the sample service to the knowledge of the action service. This is to ensure that when the action service makes a call to the sample service, it is able to retrieve sample attributes and expose them within the service.

# How to test?

1. Modify application-test.yml in rm-action-service: rabbitmq, redis, postgres to point to the main docker environment's own ports, rather than those used in docker-compose.

2. Run all the integration tests in action service - ensure there are no connection refused errors, particularly relating to the SampleSvcClientService.

