### PR TITLE
Remove branch name from image now that Python app is master

### DIFF
--- a/ras-services.yml
+++ b/ras-services.yml
@@ -161,7 +161,7 @@ services:
 
   respondent-home-ui:
     container_name: respondent-home-ui
-    image: sdcplatform/respondent-home-ui:aiohttp-app
+    image: sdcplatform/respondent-home-ui
     ports:
       - 9092:9092
     environment:


### PR DESCRIPTION
Does what it says on the tin. sdcplatform/respondent-home-ui:latest is now the Python rewrite.