### PR TITLE
Change user id to allow travis to write file

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -25,7 +25,7 @@ services:
         - ~/Documents/sftp:/home/centos/Documents/sftp
     ports:
         - "${EX_SFTP_PORT}:22"
-    command: centos:JLibV2&XD,:1001
+    command: centos:JLibV2&XD,:2000
  cfdatabasetool:
   container_name: cfdatabasetool
   image: sdcplatform/cfdatabasetool


### PR DESCRIPTION
# Motivation and Context
As found in this github issue the user id is 2000
https://github.com/travis-ci/travis-ci/issues/7995.
This allows the sftp service to write the files.

# What has changed
UID set to 2000

# How to test?
- [x] Acceptance tests should still pass
- [x] [Integration tests in action exporter pass](https://github.com/ONSdigital/rm-actionexporter-service/pull/42)

# Links
https://trello.com/c/Ii0xwuGt/225-add-acceptance-test-for-generating-notification-file
