### PR TITLE
Enable basic auth for java services

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -14,6 +14,7 @@ services:
      - sftp
      - party
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - liquibase_url=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_PORT=${RABBIT_PORT}
@@ -52,6 +53,7 @@ services:
      - rabbitmq
      - redis
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -89,6 +91,7 @@ services:
      - rabbitmq
      - redis
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -132,6 +135,7 @@ services:
      - redis
      - sftp
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -168,6 +172,7 @@ services:
      - rabbitmq
      - redis
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -200,6 +205,7 @@ services:
      - redis
      - sftp
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -232,6 +238,7 @@ services:
      - rabbitmq
      - redis
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
      - LIQUIBASE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}
      - RABBITMQ_HOST=${RABBIT_HOST}
@@ -294,6 +301,7 @@ services:
      - rabbitmq
      - postgres
     environment:
+     - SECURITY_BASIC_ENABLED=true
      - RABBITMQ_HOST=${RABBIT_HOST}
      - RABBITMQ_PORT=${RABBIT_PORT}
      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Looks like Springboot services default basic auth to false. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
 Added config to enable basic auth for java services.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Java services spun up with master branch allows access without basic auth.
Using this branch and hitting one of the java services `http://0.0.0.0:8151/actionplans` should prompt you for basic auth/ give 401.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
