### PR TITLE
Fix te readme to refer 'sdcplatform' instead of 'sdcplatformras'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A combined repository for unifying approach to running RAS and RM in Docker
 
 ## Pre-requisites
 1. Create a docker hub account
-1. Ask to become a team member of sdcplatformras
+1. Ask to become a team member of sdcplatform
 1. Run `docker login` in a terminal and use your docker hub account
 1. Run `docker network create rasrmdockerdev_default` to create the docker network
 


### PR DESCRIPTION
# Motivation and Context
The README is currently telling people to request access to the wrong dockerhub team

# What has changed
the README.md has been updated to refer to 'sdcplatform' not 'sdcplatformras'

