### PR TITLE
Update UAA client ID for response-operations-social-ui

### DIFF
--- a/ras-local.yml
+++ b/ras-local.yml
@@ -309,7 +309,7 @@ services:
       - EXPLAIN_TEMPLATE_LOADING=True
       - RAS_SECURE_MESSAGING_JWT_SECRET=${JWT_SECRET}
       - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=response_operations
+      - UAA_CLIENT_ID=response_operations_social
       - UAA_CLIENT_SECRET=password
       - ZIPKIN_DSN=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/api/v1/spans
       - ZIPKIN_SAMPLE_RATE=100

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -281,7 +281,7 @@ services:
       - SECURE_MESSAGE_URL=http://${SECURE_MESSAGE_HOST}:${SECURE_MESSAGE_PORT}
       - RAS_SECURE_MESSAGING_JWT_SECRET=${JWT_SECRET}
       - UAA_SERVICE_URL=http://${UAA_HOST}:${UAA_PORT}
-      - UAA_CLIENT_ID=response_operations
+      - UAA_CLIENT_ID=response_operations_social
       - UAA_CLIENT_SECRET=password
       - ZIPKIN_DSN=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/api/v1/spans
       - ZIPKIN_SAMPLE_RATE=100


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A recent change was added run response-operations-social-ui. The `UAA_CLIENT_ID` will need to change to `response_operations_social` to match the credentials set in `uaa.yml`

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* ras-services.yml
* ras-local.yml

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* make up
* Try logging into response-operations-social-ui with the test uaa_user ID.