### PR TITLE
Add CASCADE to dropping of pgcrypto in database setup

### DIFF
--- a/setup_database.py
+++ b/setup_database.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     conn = retry_connection(engine)
 
     print('Dropping pgcrypto')
-    conn.execute('DROP EXTENSION IF EXISTS pgcrypto;')
+    conn.execute('DROP EXTENSION IF EXISTS pgcrypto CASCADE;')
     print('Creating pgcrypto')
     conn.execute('CREATE EXTENSION pgcrypto WITH SCHEMA public;')
 


### PR DESCRIPTION
# Motivation and Context
The changes for a bug fix in actionexporter service include using `gen_random_uuid` from the pgcrypto extension as a default value. As a result the setup file here which drops and recreates pgcrypto can't run unless it is `CASCADE` because of the dependency on the extension.

# What has changed
- Add CASCADE to dropping of pgcrypto in database setup

# How to test?
- Start up the services in docker dev on the action exporter address fix branches:
https://github.com/ONSdigital/rm-action-service/pull/116
https://github.com/ONSdigital/rm-actionsvc-api/pull/34
https://github.com/ONSdigital/rm-actionexporter-service/pull/66
- Run a `make down` and then `make up` again, the setup database step should still work

# Links
[Trello](https://trello.com/c/BNWyG8P1/260-bug200-addresses-are-not-being-updated-when-a-new-one-for-that-ru-is-being-updated-20)
https://github.com/ONSdigital/rm-actionexporter-service/pull/66