### PR TITLE
Remove restart: always from all services

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -16,7 +16,7 @@ services:
     image: openzipkin/zipkin
     ports:
     - "${EX_ZIPKIN_PORT}:9411"
-    rabbitmq:
+  rabbitmq:
     container_name: rabbitmq
     image: rabbitmq:3.6.10-management
     ports:

--- a/dev.yml
+++ b/dev.yml
@@ -1,69 +1,78 @@
 version: '3'
 services:
- ons-postgres:
-  container_name: postgres
-  image: sdcplatform/ras-rm-docker-postgres
-  command: ["-c", "shared_buffers=256MB", "-c", "max_connections=200"]
-  ports:
-   - "${EX_POSTGRES_PORT}:5432"
- redis:
-  container_name: redis
-  image: redis:3.2.9
-  ports:
-   - "${EX_REDIS_PORT}:6379"
- zipkin:
-  container_name: zipkin
-  image: openzipkin/zipkin
-  ports:
-  - "${EX_ZIPKIN_PORT}:9411"
- rabbitmq:
-  container_name: rabbitmq
-  image: rabbitmq:3.6.10-management
-  ports:
-    - "5369:4369"
-    - "45672:25672"
-    - "${EX_RABBIT_PORT}:5671-5672"
-    - "16671-16672:15671-15672"
- sftp:
+  ons-postgres:
+    container_name: postgres
+    image: sdcplatform/ras-rm-docker-postgres
+    restart: always
+    command: ["-c", "shared_buffers=256MB", "-c", "max_connections=200"]
+    ports:
+      - "${EX_POSTGRES_PORT}:5432"
+  redis:
+    container_name: redis
+    image: redis:3.2.9
+    restart: always
+    ports:
+    - "${EX_REDIS_PORT}:6379"
+  zipkin:
+    container_name: zipkin
+    image: openzipkin/zipkin
+    restart: always
+    ports:
+    - "${EX_ZIPKIN_PORT}:9411"
+    rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3.6.10-management
+    restart: always
+    ports:
+      - "5369:4369"
+      - "45672:25672"
+      - "${EX_RABBIT_PORT}:5671-5672"
+      - "16671-16672:15671-15672"
+  sftp:
     container_name: sftp
     image: atmoz/sftp
+    restart: always
     volumes:
         - ~/Documents/sftp:/home/centos/Documents/sftp
     ports:
         - "${EX_SFTP_PORT}:22"
     command: centos:JLibV2&XD,:2000
- cfdatabasetool:
-  container_name: cfdatabasetool
-  image: sdcplatform/cfdatabasetool
-  environment:
-   - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/postgres
-   - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=12000
-  ports:
-   - "9000:9000"
-   - "12000:12000"
- pgadmin:
-  container_name: pgadmin
-  image: dpage/pgadmin4
-  ports:
-   - "80:80"
-  environment:
-   - PGADMIN_DEFAULT_EMAIL=ons@ons.gov
-   - PGADMIN_DEFAULT_PASSWORD=secret
-  links:
-   - ons-postgres:postgres
- uaa:
-  container_name: uaa
-  image: sdcplatform/uaa:0.0.1
-  ports:
-    - "9080:8080"
-  volumes:
-    - ./uaa:/uaa
-  environment:
-    - CATALINA_OPTS="-Dspring.profiles.active=postgresql"
-  links:
-   - ons-postgres:postgres
- rasrm-ops:
-  container_name: rasrm-ops
-  image: sdcplatform/rasrm-ops
-  ports:
-  - "8003:80"
+  cfdatabasetool:
+    container_name: cfdatabasetool
+    image: sdcplatform/cfdatabasetool
+    restart: always
+    environment:
+    - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/postgres
+    - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=12000
+    ports:
+    - "9000:9000"
+    - "12000:12000"
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4
+    restart: always
+    ports:
+    - "80:80"
+    environment:
+    - PGADMIN_DEFAULT_EMAIL=ons@ons.gov
+    - PGADMIN_DEFAULT_PASSWORD=secret
+    links:
+    - ons-postgres:postgres
+  uaa:
+    container_name: uaa
+    image: sdcplatform/uaa:0.0.1
+    restart: always
+    ports:
+      - "9080:8080"
+    volumes:
+      - ./uaa:/uaa
+    environment:
+      - CATALINA_OPTS="-Dspring.profiles.active=postgresql"
+    links:
+    - ons-postgres:postgres
+  rasrm-ops:
+    container_name: rasrm-ops
+    image: sdcplatform/rasrm-ops
+    restart: always
+    ports:
+    - "8003:80"

--- a/dev.yml
+++ b/dev.yml
@@ -3,26 +3,22 @@ services:
   ons-postgres:
     container_name: postgres
     image: sdcplatform/ras-rm-docker-postgres
-    restart: always
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=200"]
     ports:
       - "${EX_POSTGRES_PORT}:5432"
   redis:
     container_name: redis
     image: redis:3.2.9
-    restart: always
     ports:
     - "${EX_REDIS_PORT}:6379"
   zipkin:
     container_name: zipkin
     image: openzipkin/zipkin
-    restart: always
     ports:
     - "${EX_ZIPKIN_PORT}:9411"
     rabbitmq:
     container_name: rabbitmq
     image: rabbitmq:3.6.10-management
-    restart: always
     ports:
       - "5369:4369"
       - "45672:25672"
@@ -31,7 +27,6 @@ services:
   sftp:
     container_name: sftp
     image: atmoz/sftp
-    restart: always
     volumes:
         - ~/Documents/sftp:/home/centos/Documents/sftp
     ports:
@@ -40,7 +35,6 @@ services:
   cfdatabasetool:
     container_name: cfdatabasetool
     image: sdcplatform/cfdatabasetool
-    restart: always
     environment:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/postgres
     - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=12000
@@ -50,7 +44,6 @@ services:
   pgadmin:
     container_name: pgadmin
     image: dpage/pgadmin4
-    restart: always
     ports:
     - "80:80"
     environment:
@@ -61,7 +54,6 @@ services:
   uaa:
     container_name: uaa
     image: sdcplatform/uaa:0.0.1
-    restart: always
     ports:
       - "9080:8080"
     volumes:
@@ -73,6 +65,5 @@ services:
   rasrm-ops:
     container_name: rasrm-ops
     image: sdcplatform/rasrm-ops
-    restart: always
     ports:
     - "8003:80"

--- a/ras-local.yml
+++ b/ras-local.yml
@@ -27,7 +27,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PARTY_PORT}/info"]
       interval: 1m30s
@@ -63,7 +62,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${SECURE_MESSAGE_PORT}/info"]
       interval: 1m30s
@@ -115,7 +113,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${FRONTSTAGE_PORT}/info"]
       interval: 1m30s
@@ -150,7 +147,6 @@ services:
       - rasrmdockerdev_default
     external_links:
       - postgres:ras-postgres
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${COLL_INST_PORT}/info"]
       interval: 1m30s
@@ -173,7 +169,6 @@ services:
       - postgres:ras-postgres
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8040/info"]
       interval: 1m30s
@@ -211,7 +206,6 @@ services:
       - SURVEY_PASSWORD=${SECURITY_USER_PASSWORD}
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9092/info"]
       interval: 1m30s
@@ -265,7 +259,6 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8085/info"]
       interval: 1m30s
@@ -318,7 +311,6 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/info"]
       interval: 1m30s

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -25,7 +25,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PARTY_PORT}/info"]
       interval: 1m30s
@@ -56,7 +55,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${SECURE_MESSAGE_PORT}/info"]
       interval: 1m30s
@@ -105,7 +103,6 @@ services:
       - ZIPKIN_SAMPLE_RATE=100
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${FRONTSTAGE_PORT}/info"]
       interval: 1m30s
@@ -137,7 +134,6 @@ services:
       - rasrmdockerdev_default
     external_links:
       - postgres:ras-postgres
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${COLL_INST_PORT}/info"]
       interval: 1m30s
@@ -158,7 +154,6 @@ services:
       - postgres:ras-postgres
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8040/info"]
       interval: 1m30s
@@ -182,7 +177,6 @@ services:
       - postgres:ras-postgres
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8041/info"]
       interval: 1m30s
@@ -221,7 +215,6 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9092/info"]
       interval: 1m30s
@@ -270,7 +263,6 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8085/info"]
       interval: 1m30s
@@ -318,7 +310,6 @@ services:
       - redis
     networks:
       - rasrmdockerdev_default
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/info"]
       interval: 1m30s

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -36,7 +36,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8125/info"]
       interval: 1m30s
@@ -76,7 +75,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8171/info"]
       interval: 1m30s
@@ -121,7 +119,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8151/info"]
       interval: 1m30s
@@ -161,7 +158,6 @@ services:
      - EXPORT_SCHEDULE_CRON_EXPRESSION=*/30 * * * * *
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8141/info"]
       interval: 1m30s
@@ -195,7 +191,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8121/info"]
       interval: 1m30s
@@ -231,7 +226,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8191/info"]
       interval: 1m30s
@@ -280,7 +274,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8145/info"]
       interval: 1m30s
@@ -301,7 +294,6 @@ services:
      - ZIPKIN_DSN=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/api/v1/spans
      - ZIPKIN_SAMPLE_RATE=1.0
      - ZIPKIN_DISABLE=False
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/info"]
       interval: 1m30s
@@ -330,7 +322,6 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
      - SPRING_ZIPKIN_ENABLED=true
      - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "-XGET", "http://localhost:8181/info"]
       interval: 1m30s
@@ -350,7 +341,6 @@ services:
       - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
       - SPRING_ZIPKIN_ENABLED=true
       - SPRING_ZIPKIN_BASEURL=http://${ZIPKIN_HOST}:${ZIPKIN_PORT}/
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "-XGET", "http://localhost:8182/info"]
       interval: 1m30s
@@ -368,7 +358,6 @@ services:
       - DATABASE_URI=postgres://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres
       - SECURITY_USER_NAME=${SECURITY_USER_NAME}
       - SECURITY_USER_PASSWORD=${SECURITY_USER_PASSWORD}
-    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "-XGET", "http://localhost:8084/info"]
       interval: 1m30s


### PR DESCRIPTION
# Motivation and Context
~The ras/rm services always restart when docker starts, but the backing services do not.  This results in spinning only part of the system and having it all be totally useless.  This sort of thing should be an all or nothing proposition.~

Having all of the services start on machine startup wastes system resources, heats up your laptop, and makes switching between services (this and SDX for example) a pain.  Having the system only startup when you request it is probably the right thing to do.

# What has changed
  - ~Added restart: always to the backing services~
  - Removed all instances of restart:always
  - reindented the file so it's consistent with others

# How to test?
Spin it up and see if it works!

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
