### PR TITLE
Remove django-oauth2-test service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOT := $(shell command -v dot 2> /dev/null)
 
-RAS_REPOS="ras-party" "ras-secure-message" "ras-frontstage" "ras-collection-instrument" "django-oauth2-test" "ras-rm-auth-service" "respondent-home-ui" "response-operations-ui" "response-operations-social-ui" "rasrm-ops"
+RAS_REPOS="ras-party" "ras-secure-message" "ras-frontstage" "ras-collection-instrument" "ras-rm-auth-service" "respondent-home-ui" "response-operations-ui" "response-operations-social-ui" "rasrm-ops"
 RM_REPOS="rm-sample-service" "rm-case-service" "rm-action-service" "rm-actionexporter-service" "iac-service" "rm-sdx-gateway" "rm-collection-exercise-service" "rm-survey-service" "rm-notify-gateway" "rm-comms-template-service" "rm-reporting"
 REPOS=${RAS_REPOS} ${RM_REPOS}
 
@@ -39,7 +39,7 @@ build: clone
 	done
 
 up:
-	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE} ; docker stop oauth2-service && docker start oauth2-service
+	docker-compose -f dev.yml -f ras-services.yml -f rm-services.yml up -d ${SERVICE}
 	pipenv install --dev
 	pipenv run python setup_database.py
 

--- a/ras-local.yml
+++ b/ras-local.yml
@@ -153,28 +153,6 @@ services:
       timeout: 10s
       retries: 3
 
-  oauth2-service:
-    container_name: oauth2-service
-    build: ${RAS_HOME}/django-oauth2-test
-    volumes:
-      - ${RAS_HOME}/django-oauth2-test:/app
-    ports:
-      - 8040:8040
-    environment:
-      - OAUTH2_SUPER_USER=admin
-      - OAUTH2_SUPER_USER_PASSWORD=admin2017
-      - OAUTH2_SUPER_USER_EMAIL=admin@email.com
-      - DJANGO_SETTINGS_MODULE=proj.settings.docker
-    external_links:
-      - postgres:ras-postgres
-    networks:
-      - rasrmdockerdev_default
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8040/info"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
-
   respondent-home-ui:
     container_name: respondent-home-ui
     build: ${RAS_HOME}/respondent-home-ui

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -140,26 +140,6 @@ services:
       timeout: 10s
       retries: 3
 
-  oauth2-service:
-    container_name: oauth2-service
-    image: sdcplatform/django-oauth2-test
-    ports:
-      - 8040:8040
-    environment:
-      - OAUTH2_SUPER_USER=admin
-      - OAUTH2_SUPER_USER_PASSWORD=admin2017
-      - OAUTH2_SUPER_USER_EMAIL=admin@email.com
-      - DJANGO_SETTINGS_MODULE=proj.settings.docker
-    external_links:
-      - postgres:ras-postgres
-    networks:
-      - rasrmdockerdev_default
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8040/info"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
-
   auth-service:
     container_name: auth-service
     image: sdcplatform/ras-rm-auth-service


### PR DESCRIPTION
# Motivation and Context
We've moved to ras-rm-auth-service, so we can stop using the django-oauth-test service.

# What has changed
Removed the django service from the docker files so that we're running less containers

# How to test?
 - Build the containers.  Make sure that the django service doesn't appear.
 - Ensure the acceptance tests still pass.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
