### PR TITLE
Change R-Ops UAA client to have OAuth login permissions

### DIFF
--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -105,8 +105,8 @@ oauth:
             id: response_operations
             secret: password
             authorized-grant-types: client_credentials,password
-            authorities: scim.userids, scim.me, scim.read
-            scope: scim.userids, scim.me, scim.read
+            authorities: scim.userids, scim.me, scim.read, oauth.login
+            scope: scim.userids, scim.me, scim.read, oauth.login
             resource-ids: oauth
           response_operations_social:
             id: response_operations_social


### PR DESCRIPTION
# Motivation and Context
The `response-operations` client requires `oauth.login` authorisation to do a password change for a user that's forgotten their password