### PR TITLE
Remove superfluous '-service' from certain services

### DIFF
--- a/.env
+++ b/.env
@@ -86,7 +86,7 @@ SURVEY_USERNAME=admin
 SURVEY_PASSWORD=secret
 
 # Party
-PARTY_HOST=party-service
+PARTY_HOST=party
 PARTY_PORT=8081
 PARTY_USER=admin
 PARTY_USERNAME=admin

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ make: *** [pull] Error 1
 
 ### Port already bound to
 ```
-ERROR: for collection-instrument  Cannot start service collection-instrument-service: driver failed programming external connectivity on endpoint collection-instrument (7c6ad787c9d57028a44848719d8d705b14e1f82ea2f393ada80e5f7e476c50b1): Error starting userland pStarting secure-message ... done
+ERROR: for collection-instrument  Cannot start service collection-instrument: driver failed programming external connectivity on endpoint collection-instrument (7c6ad787c9d57028a44848719d8d705b14e1f82ea2f393ada80e5f7e476c50b1): Error starting userland pStarting secure-message ... done
 
-ERROR: for collection-instrument-service  Cannot start service collection-instrument-service: driver failed programming external connectivity on endpoint collection-instrument (7c6ad787c9d57028a44848719d8d705b14e1f82ea2f393ada80e5f7e476c50b1): Error starting userland proxy: Bind for 0.0.0.0:8002 failed: port is already allocated
+ERROR: for collection-instrument  Cannot start service collection-instrument: driver failed programming external connectivity on endpoint collection-instrument (7c6ad787c9d57028a44848719d8d705b14e1f82ea2f393ada80e5f7e476c50b1): Error starting userland proxy: Bind for 0.0.0.0:8002 failed: port is already allocated
 ERROR: Encountered errors while bringing up the project.
 make: *** [up] Error 1
 ```

--- a/ras-local.yml
+++ b/ras-local.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-  party-service:
-    container_name: party-service
+  party:
+    container_name: party
     build: ${RAS_HOME}/ras-party
     volumes:
       - ${RAS_HOME}/ras-party:/app
@@ -33,7 +33,7 @@ services:
       timeout: 10s
       retries: 3
 
-  secure-message-service:
+  secure-message:
     container_name: secure-message
     build: ${RAS_HOME}/ras-secure-message
     volumes:
@@ -119,7 +119,7 @@ services:
       timeout: 10s
       retries: 3
 
-  collection-instrument-service:
+  collection-instrument:
     container_name: collection-instrument
     build: ${RAS_HOME}/ras-collection-instrument
     volumes:

--- a/ras-services.yml
+++ b/ras-services.yml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
 
-  party-service:
-    container_name: party-service
+  party:
+    container_name: party
     image: sdcplatform/ras-party
     ports:
       - "${PARTY_PORT}:${PARTY_PORT}"
@@ -31,7 +31,7 @@ services:
       timeout: 10s
       retries: 3
 
-  secure-message-service:
+  secure-message:
     container_name: secure-message
     image: sdcplatform/ras-secure-message
     ports:
@@ -109,7 +109,7 @@ services:
       timeout: 10s
       retries: 3
 
-  collection-instrument-service:
+  collection-instrument:
     container_name: collection-instrument
     image: sdcplatform/ras-collection-instrument
     ports:


### PR DESCRIPTION
# Motivation and Context
A bunch of the names were inconsistent, some had -service at the end and some didnt' (`party-service` vs `frontstage` for example).  It was a pain to know how to turn off a container by name.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
